### PR TITLE
fix: Listener's Reflection should work on all messages not caught by the sifter's prefix

### DIFF
--- a/Fabric/src/main/java/ram/talia/moreiotas/fabric/eventhandlers/ChatEventHandler.kt
+++ b/Fabric/src/main/java/ram/talia/moreiotas/fabric/eventhandlers/ChatEventHandler.kt
@@ -22,8 +22,10 @@ object ChatEventHandler {
             return true
         }
 
-        if (!text.startsWith(prefix))
+        if (!text.startsWith(prefix)) {
+            lastMessage = text
             return true
+        }
 
         lastMessages[player.uuid] = text.substring(prefix.length)
 

--- a/Forge/src/main/java/ram/talia/moreiotas/forge/eventhandlers/ChatEventHandler.java
+++ b/Forge/src/main/java/ram/talia/moreiotas/forge/eventhandlers/ChatEventHandler.java
@@ -56,8 +56,8 @@ public class ChatEventHandler {
             event.setCanceled(true);
             lastMessages.put(uuid, text.substring(prefix.length()));
             return;
+        } else {
+            lastMessage = text;
         }
-
-        lastMessage = text;
     }
 }


### PR DESCRIPTION
See title. This also fixes forge behavior where messages caught by a sifter's prefix will still show up on listener's reflection (for all players).

Likely resolves #28